### PR TITLE
Updated error in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ import {JsonDiffer} from "https://rawgit.com/lukascivil/jsondiffer/master/dist.b
 
 ## Usage
 
-`getDiff(oldStruct, newStruct)`
+`getDiff(newStruct, oldStruct)`
 
-Returns the structural diff between `oldStruct` and `newStruct`.
+Returns the structural diff between `newStruct` and `oldStruct`.
 
 ## Example
 


### PR DESCRIPTION
Hi,

I noticed an error in the documentation regarding the getDiff method. The parameters were around the wrong way regarding the old and new JSON structure.

Cheers.