### PR TITLE
chore: build playground before deploying to github pages

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -90,6 +90,10 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+      - name: Build Playground
+        if: github.event.inputs.dry_run != 'true'
+        run: yarn nx run-many --target=build --projects=playground
+
       - name: Deploy Playground to Github Pages 🚀
         if: github.event.inputs.dry_run != 'true'
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
## Objective

Ensure the playground's production bundle is built before the GitHub Pages deploy step runs, so the deployed site reflects the current release instead of stale or missing build output.

## What was done

- Added a `Build Playground` step in `.github/workflows/release-and-publish.yml` that runs `yarn nx run-many --target=build --projects=playground` immediately before the `Deploy Playground to Github Pages` step.
- Gated the new step with `if: github.event.inputs.dry_run != 'true'`, mirroring the existing deploy step so dry-run executions still skip both build and deploy.

## Test plan

- [ ] Trigger the `release-and-publish` workflow with `dry_run=true` and confirm the new Build Playground step is skipped along with the deploy step.
- [ ] Trigger the workflow with `dry_run=false` and confirm the Build Playground step runs successfully and produces the artifact consumed by the deploy step.
- [ ] Verify the GitHub Pages site is updated with the latest playground build after the run.